### PR TITLE
chore(deps)!: update estree-walker to v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@types/node": "latest",
     "c8": "latest",
     "eslint": "latest",
+    "jiti": "^1.14.0",
     "standard-version": "latest",
     "typescript": "latest",
     "unbuild": "latest",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
       "types": "./dist/transform.d.ts"
     },
     "./plugin": {
-      "require": "./dist/plugin.cjs",
       "import": "./dist/plugin.mjs",
       "types": "./dist/plugin.d.ts"
     }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "acorn": "^8.8.0",
-    "estree-walker": "^2.0.2",
+    "estree-walker": "^3.0.1",
     "magic-string": "^0.26.2",
     "unplugin": "^0.8.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ specifiers:
   c8: latest
   eslint: latest
   estree-walker: ^3.0.1
+  jiti: ^1.14.0
   magic-string: ^0.26.2
   standard-version: latest
   typescript: latest
@@ -29,6 +30,7 @@ devDependencies:
   '@types/node': 18.6.3
   c8: 7.12.0
   eslint: 8.21.0
+  jiti: 1.14.0
   standard-version: 9.5.0
   typescript: 4.7.4
   unbuild: 0.7.6

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ specifiers:
   acorn: ^8.8.0
   c8: latest
   eslint: latest
-  estree-walker: ^2.0.2
+  estree-walker: ^3.0.1
   magic-string: ^0.26.2
   standard-version: latest
   typescript: latest
@@ -18,7 +18,7 @@ specifiers:
 
 dependencies:
   acorn: 8.8.0
-  estree-walker: 2.0.2
+  estree-walker: 3.0.1
   magic-string: 0.26.2
   unplugin: 0.8.0
 
@@ -1911,6 +1911,11 @@ packages:
 
   /estree-walker/2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+    dev: true
+
+  /estree-walker/3.0.1:
+    resolution: {integrity: sha512-woY0RUD87WzMBUiZLx8NsYr23N5BKsOMZHhu2hoNRVh6NXGfoiT1KOL8G3UHlJAnEDGmfa5ubNA/AacfG+Kb0g==}
+    dev: false
 
   /esutils/2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}

--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,5 @@
 {
   "extends": [
     "@nuxtjs"
-  ],
-  "ignoreDeps": [
-    "estree-walker"
   ]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,8 @@
 import { resolve } from 'path'
 import { defineConfig } from 'vitest/config'
-import { unctxPlugin } from './src/plugin'
+// import { unctxPlugin } from './src/plugin' // TODO
+import jiti from 'jiti'
+const { unctxPlugin } = jiti(import.meta.url, { esmResolve: true })('./src/plugin')
 
 export default defineConfig({
   plugins: [


### PR DESCRIPTION
Breaking change: `unctx/plugin` only works with ESM imports after this change since `estree-walker` is also esm-only.