### PR TITLE
fix: check if awaitable is an object

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -148,7 +148,7 @@ export function executeAsync<T> (function_: AsyncFunction<T>): [Promise<T>, () =
     }
   };
   let awaitable = function_();
-  if ("catch" in awaitable) {
+  if (typeof awaitable === "object" && "catch" in awaitable) {
     awaitable = awaitable.catch((error) => {
       restore();
       throw error;

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,7 +148,7 @@ export function executeAsync<T> (function_: AsyncFunction<T>): [Promise<T>, () =
     }
   };
   let awaitable = function_();
-  if (typeof awaitable === "object" && "catch" in awaitable) {
+  if (awaitable && typeof awaitable === "object" && "catch" in awaitable) {
     awaitable = awaitable.catch((error) => {
       restore();
       throw error;

--- a/test/async.test.ts
+++ b/test/async.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import { createContext, withAsyncContext } from "../src";
 
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+const noop = () => {};
 
 describe("callAsync", () => {
   it("call and use", async () => {
@@ -85,5 +86,17 @@ describe("callAsync", () => {
     expect(console.warn).toHaveBeenCalledOnce();
     // eslint-disable-next-line no-console
     console.warn = _warn;
+  });
+
+  it("await but no async fn", async () => {
+    const context = createContext();
+    await context.callAsync("A", async () => {
+      expect(context.use()).toBe("A");
+      await noop();
+      expect(context.use()).toBe("A");
+      await "A";
+      expect(context.use()).toBe("A");
+      return context.use();
+    });
   });
 });


### PR DESCRIPTION
Resolves https://github.com/nuxt/framework/issues/9310

Adds a check if `awaitable` is an object to avoid obscure errors for end users. Also adds tests to ensure the functionality is not affected