### PR TITLE
fix(transform): insert code rather than overwriting chunk

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -176,8 +176,11 @@ export function createTransformer(options: TransformerOptions = {}) {
     function injectForNode(node: AwaitExpression, parent: Node | undefined) {
       const isStatement = parent?.type === "ExpressionStatement";
 
+      s.remove(toIndex(node.loc.start), toIndex(node.argument.loc.start))
+      s.remove(toIndex(node.loc.end), toIndex(node.argument.loc.end))
+
       s.appendLeft(
-        toIndex(node.loc.start),
+        toIndex(node.argument.loc.start),
         isStatement
           ? `;(([__temp,__restore]=__executeAsync(()=>`
           : `(([__temp,__restore]=__executeAsync(()=>`

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -176,8 +176,8 @@ export function createTransformer(options: TransformerOptions = {}) {
     function injectForNode(node: AwaitExpression, parent: Node | undefined) {
       const isStatement = parent?.type === "ExpressionStatement";
 
-      s.remove(toIndex(node.loc.start), toIndex(node.argument.loc.start))
-      s.remove(toIndex(node.loc.end), toIndex(node.argument.loc.end))
+      s.remove(toIndex(node.loc.start), toIndex(node.argument.loc.start));
+      s.remove(toIndex(node.loc.end), toIndex(node.argument.loc.end));
 
       s.appendLeft(
         toIndex(node.argument.loc.start),

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -174,19 +174,19 @@ export function createTransformer(options: TransformerOptions = {}) {
     }
 
     function injectForNode(node: AwaitExpression, parent: Node | undefined) {
-      const body = code.slice(
-        toIndex(node.argument.loc.start),
-        toIndex(node.argument.loc.end)
-      );
-
       const isStatement = parent?.type === "ExpressionStatement";
 
-      s.overwrite(
+      s.appendLeft(
         toIndex(node.loc.start),
-        toIndex(node.loc.end),
         isStatement
-          ? `;(([__temp,__restore]=__executeAsync(()=>${body})),await __temp,__restore());`
-          : `(([__temp,__restore]=__executeAsync(()=>${body})),__temp=await __temp,__restore(),__temp)`
+          ? `;(([__temp,__restore]=__executeAsync(()=>`
+          : `(([__temp,__restore]=__executeAsync(()=>`
+      );
+      s.appendRight(
+        toIndex(node.argument.loc.end),
+        isStatement
+          ? `)),await __temp,__restore());`
+          : `)),__temp=await __temp,__restore(),__temp)`
       );
     }
   }

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -211,6 +211,22 @@ describe("transforms", () => {
     `);
   });
 
+  it("transforms multiple awaits in same chunk", () => {
+    expect(
+      transform(`
+      export default withAsyncContext(async () => {
+        await writeConfig(await readConfig())
+      })
+    `)
+    ).toMatchInlineSnapshot(`
+      "import { executeAsync as __executeAsync } from \\"unctx\\";
+      export default withAsyncContext(async () => {let __temp, __restore;
+        ;(([__temp,__restore]=__executeAsync(()=>writeConfig((([__temp,__restore]=__executeAsync(()=>readConfig())),__temp=await __temp,__restore(),__temp)))),await __temp,__restore());
+      },1)
+      "
+    `);
+  });
+
   it("does not transform non target function", () => {
     expect(
       transform(`

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -167,7 +167,7 @@ describe("transforms", () => {
     ).toBeUndefined();
   });
 
-  it("does not transform nested functions", () => {
+  it("does not transform unrelated nested functions", () => {
     expect(
       transform(`
       export default withAsyncContext(async () => {
@@ -181,6 +181,34 @@ describe("transforms", () => {
       })
     `)
     ).toBeUndefined();
+  });
+
+  it("transforms validly nested functions", () => {
+    expect(
+      transform(`
+      export default withAsyncContext(async () => {
+        await something()
+
+        withAsyncContext(async () => {
+          await something()
+        })
+
+        const ctx = useSomething()
+      })
+    `)
+    ).toMatchInlineSnapshot(`
+      "import { executeAsync as __executeAsync } from \\"unctx\\";
+      export default withAsyncContext(async () => {let __temp, __restore;
+        ;(([__temp,__restore]=__executeAsync(()=>something())),await __temp,__restore());
+
+        withAsyncContext(async () => {let __temp, __restore;
+          ;(([__temp,__restore]=__executeAsync(()=>something())),await __temp,__restore());
+        },1)
+
+        const ctx = useSomething()
+      },1)
+      "
+    `);
   });
 
   it("does not transform non target function", () => {


### PR DESCRIPTION
~> https://github.com/nuxt/nuxt/issues/20444

When we have nested transforms (such as a Nuxt hook within a Nuxt plugin) we will currently get an error when trying to overwrite or modify the 'inner' transform. This approach instead inserts code on either side of the function to avoid mutating the same chunk twice.