### PR TITLE
fix(transform): don't terminate single if statements

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -163,15 +163,6 @@ export function createTransformer(options: TransformerOptions = {}) {
             injectVariable = true;
             (node.consequent.expression as MaybeHandledNode).__injected = true;
             injectForNode(node.consequent.expression, node);
-          } else if (
-            node.type === "IfStatement" &&
-            node.consequent.type === "ExpressionStatement" &&
-            node.consequent.expression.type === "AwaitExpression"
-          ) {
-            detected = true;
-            injectVariable = true;
-            (node.consequent.expression as MaybeHandledNode).__injected = true;
-            injectForNode(node.consequent.expression, node);
           }
           // Skip transform for nested functions
           if (

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -33,8 +33,10 @@ export interface TransformerOptions {
   objectDefinitions?: Record<string, string[]>;
 }
 
+const kInjected = "__unctx_injected__";
+
 type MaybeHandledNode = Node & {
-  __injected?: boolean;
+  [kInjected]?: boolean;
 };
 
 export function createTransformer(options: TransformerOptions = {}) {
@@ -150,7 +152,7 @@ export function createTransformer(options: TransformerOptions = {}) {
       let injectVariable = false;
       walk(body, {
         enter(node: MaybeHandledNode, parent: MaybeHandledNode | undefined) {
-          if (node.type === "AwaitExpression" && !node.__injected) {
+          if (node.type === "AwaitExpression" && !node[kInjected]) {
             detected = true;
             injectVariable = true;
             injectForNode(node, parent);
@@ -161,7 +163,7 @@ export function createTransformer(options: TransformerOptions = {}) {
           ) {
             detected = true;
             injectVariable = true;
-            (node.consequent.expression as MaybeHandledNode).__injected = true;
+            (node.consequent.expression as MaybeHandledNode)[kInjected] = true;
             injectForNode(node.consequent.expression, node);
           }
           // Skip transform for nested functions

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -302,4 +302,19 @@ describe("transforms", () => {
     `)
     ).toBeUndefined();
   });
+  it("Should not add a statement terminator if expression comes after if statement", () => {
+    expect(
+      transform(`
+      export default withAsyncContext(async () => {
+        if(false) await something()
+      })
+    `)
+    ).toMatchInlineSnapshot( `
+      "import { executeAsync as __executeAsync } from \\"unctx\\";
+      export default withAsyncContext(async () => {let __temp, __restore;
+        if(false) (([__temp,__restore]=__executeAsync(()=>something())),__temp=await __temp,__restore(),__temp)
+      },1)
+      "
+    `);
+  });
 });


### PR DESCRIPTION
fix https://github.com/nuxt/nuxt/issues/30138

This PR make sure that `if (...) await soething()` don't get transformed into `if (...); ...`

<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->
