### PR TITLE
feat(plugin): support `transformFilter` option

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,7 +1,12 @@
-import { createUnplugin } from "unplugin";
+import { createUnplugin, type HookFilter } from "unplugin";
 import { createTransformer, type TransformerOptions } from "./transform";
 
 export interface UnctxPluginOptions extends TransformerOptions {
+  /** Plugin Hook Filter for the transform hook
+   * @see https://unplugin.unjs.io/guide/#filters
+   */
+  transformFilter?: HookFilter;
+  /** Function to determine whether a file should be transformed. If possible, use `transformFilter` instead for better performance.  */
   transformInclude?: (id: string) => boolean;
 }
 
@@ -12,17 +17,20 @@ export const unctxPlugin = createUnplugin(
       name: "unctx:transform",
       enforce: "post",
       transformInclude: options.transformInclude,
-      transform(code, id) {
-        const result = transformer.transform(code);
-        if (result) {
-          return {
-            code: result.code,
-            map: result.magicString.generateMap({
-              source: id,
-              includeContent: true,
-            }),
-          };
-        }
+      transform: {
+        filter: options.transformFilter,
+        handler(code, id) {
+          const result = transformer.transform(code);
+          if (result) {
+            return {
+              code: result.code,
+              map: result.magicString.generateMap({
+                source: id,
+                includeContent: true,
+              }),
+            };
+          }
+        },
       },
     };
   },


### PR DESCRIPTION
This PR adds an optional hook filter for the `transform` hook. I've also added JSDoc to explain why it is preferred over `transformInclude`

Related: https://github.com/e18e/ecosystem-issues/issues/171