### PR TITLE
perf(transform): skip parsing files without `await`

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -35,6 +35,8 @@ export interface TransformerOptions {
 
 const kInjected = "__unctx_injected__";
 
+const AWAIT_RE = /(?<![\w$.])await(?![\w$])/;
+
 type MaybeHandledNode = Node & {
   [kInjected]?: boolean;
 };
@@ -66,7 +68,9 @@ export function createTransformer(options: TransformerOptions = {}): {
   );
 
   function shouldTransform(code: string): boolean {
-    return typeof code === "string" && matchRE.test(code);
+    return (
+      typeof code === "string" && matchRE.test(code) && AWAIT_RE.test(code)
+    );
   }
 
   const filter = {

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -317,4 +317,33 @@ describe("transforms", () => {
       "
     `);
   });
+
+  describe("shouldTransform", () => {
+    it("requires both a matched function and an await", () => {
+      // matched function + await -> candidate for transform
+      expect(
+        transformer.shouldTransform(
+          "withAsyncContext(async () => { await x() })",
+        ),
+      ).toBe(true);
+      // matched function but no await -> nothing to rewrite, skip the parse
+      expect(
+        transformer.shouldTransform("withAsyncContext(async () => { x() })"),
+      ).toBe(false);
+      // await but no matched function
+      expect(transformer.shouldTransform("async () => { await x() }")).toBe(
+        false,
+      );
+      // `await` must be the keyword, not part of an identifier
+      expect(
+        transformer.shouldTransform("withAsyncContext(() => awaitable())"),
+      ).toBe(false);
+      expect(
+        transformer.shouldTransform("withAsyncContext(() => obj.await())"),
+      ).toBe(false);
+      expect(
+        transformer.shouldTransform("withAsyncContext(() => $await())"),
+      ).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
Thightens `shouldTransform` given that `await` is needed as keyword.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened transformation eligibility so code is only processed when it includes both a supported target function call and a real `await` keyword.
  * Avoids triggering on lookalike or unrelated patterns that merely contain “await” text.
* **Tests**
  * Expanded `shouldTransform` test coverage with additional negative and edge-case inputs (e.g., target call without `await`, `await` without the target call, and non-keyword “await” usage).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->