### PR TITLE
fix: avoid leaking instances via AsyncLocalStorage with WeakRef

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "changelogen": "^0.6.2",
     "eslint": "^9.39.2",
     "eslint-config-unjs": "^0.5.0",
+    "jiti": "^2.7.0",
     "obuild": "^0.4.8",
     "prettier": "^3.7.4",
     "typescript": "^5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,16 +29,19 @@ importers:
         version: 25.0.2
       '@vitest/coverage-v8':
         specifier: ^4.0.16
-        version: 4.0.16(vitest@4.0.16(@types/node@25.0.2)(jiti@2.6.1))
+        version: 4.0.16(vitest@4.0.16(@types/node@25.0.2)(jiti@2.7.0))
       changelogen:
         specifier: ^0.6.2
         version: 0.6.2(magicast@0.5.1)
       eslint:
         specifier: ^9.39.2
-        version: 9.39.2(jiti@2.6.1)
+        version: 9.39.2(jiti@2.7.0)
       eslint-config-unjs:
         specifier: ^0.5.0
-        version: 0.5.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+        version: 0.5.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
+      jiti:
+        specifier: ^2.7.0
+        version: 2.7.0
       obuild:
         specifier: ^0.4.8
         version: 0.4.8(magicast@0.5.1)(typescript@5.9.3)
@@ -50,7 +53,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@types/node@25.0.2)(jiti@2.6.1)
+        version: 4.0.16(@types/node@25.0.2)(jiti@2.7.0)
 
 packages:
 
@@ -1329,8 +1332,8 @@ packages:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
 
-  jiti@2.6.1:
-    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
   js-tokens@9.0.1:
@@ -1898,9 +1901,9 @@ snapshots:
   '@esbuild/win32-x64@0.27.1':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.0(eslint@9.39.2(jiti@2.6.1))':
+  '@eslint-community/eslint-utils@4.9.0(eslint@9.39.2(jiti@2.7.0))':
     dependencies:
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
@@ -2270,15 +2273,15 @@ snapshots:
 
   '@types/unist@2.0.11': {}
 
-  '@typescript-eslint/eslint-plugin@8.50.0(@typescript-eslint/parser@8.50.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.50.0(@typescript-eslint/parser@8.50.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.50.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.50.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.50.0
-      '@typescript-eslint/type-utils': 8.50.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.50.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.50.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.50.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.50.0
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.1.0(typescript@5.9.3)
@@ -2286,14 +2289,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.50.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.50.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.50.0
       '@typescript-eslint/types': 8.50.0
       '@typescript-eslint/typescript-estree': 8.50.0(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.50.0
       debug: 4.4.3
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -2316,13 +2319,13 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.50.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.50.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.50.0
       '@typescript-eslint/typescript-estree': 8.50.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.50.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.50.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
       debug: 4.4.3
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
       ts-api-utils: 2.1.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -2345,13 +2348,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.50.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.50.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.2(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.2(jiti@2.7.0))
       '@typescript-eslint/scope-manager': 8.50.0
       '@typescript-eslint/types': 8.50.0
       '@typescript-eslint/typescript-estree': 8.50.0(typescript@5.9.3)
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -2361,7 +2364,7 @@ snapshots:
       '@typescript-eslint/types': 8.50.0
       eslint-visitor-keys: 4.2.1
 
-  '@vitest/coverage-v8@4.0.16(vitest@4.0.16(@types/node@25.0.2)(jiti@2.6.1))':
+  '@vitest/coverage-v8@4.0.16(vitest@4.0.16(@types/node@25.0.2)(jiti@2.7.0))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.16
@@ -2374,7 +2377,7 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.16(@types/node@25.0.2)(jiti@2.6.1)
+      vitest: 4.0.16(@types/node@25.0.2)(jiti@2.7.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -2387,13 +2390,13 @@ snapshots:
       chai: 6.2.1
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.16(vite@7.3.0(@types/node@25.0.2)(jiti@2.6.1))':
+  '@vitest/mocker@4.0.16(vite@7.3.0(@types/node@25.0.2)(jiti@2.7.0))':
     dependencies:
       '@vitest/spy': 4.0.16
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.0(@types/node@25.0.2)(jiti@2.6.1)
+      vite: 7.3.0(@types/node@25.0.2)(jiti@2.7.0)
 
   '@vitest/pretty-format@4.0.16':
     dependencies:
@@ -2486,7 +2489,7 @@ snapshots:
       dotenv: 17.2.3
       exsolve: 1.0.8
       giget: 2.0.0
-      jiti: 2.6.1
+      jiti: 2.7.0
       ohash: 2.0.11
       pathe: 2.0.3
       perfect-debounce: 2.0.0
@@ -2630,34 +2633,34 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-unjs@0.5.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
+  eslint-config-unjs@0.5.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3):
     dependencies:
       '@eslint/js': 9.39.2
-      eslint: 9.39.2(jiti@2.6.1)
-      eslint-plugin-markdown: 5.1.0(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-unicorn: 59.0.1(eslint@9.39.2(jiti@2.6.1))
+      eslint: 9.39.2(jiti@2.7.0)
+      eslint-plugin-markdown: 5.1.0(eslint@9.39.2(jiti@2.7.0))
+      eslint-plugin-unicorn: 59.0.1(eslint@9.39.2(jiti@2.7.0))
       globals: 16.5.0
       typescript: 5.9.3
-      typescript-eslint: 8.50.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      typescript-eslint: 8.50.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-markdown@5.1.0(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-markdown@5.1.0(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
       mdast-util-from-markdown: 0.8.5
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-unicorn@59.0.1(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-unicorn@59.0.1(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.2(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.2(jiti@2.7.0))
       '@eslint/plugin-kit': 0.2.8
       ci-info: 4.3.1
       clean-regexp: 1.0.0
       core-js-compat: 3.47.0
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
       esquery: 1.6.0
       find-up-simple: 1.0.1
       globals: 16.5.0
@@ -2679,9 +2682,9 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
-  eslint@9.39.2(jiti@2.6.1):
+  eslint@9.39.2(jiti@2.7.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.2(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.2(jiti@2.7.0))
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.21.1
       '@eslint/config-helpers': 0.4.2
@@ -2716,7 +2719,7 @@ snapshots:
       natural-compare: 1.4.0
       optionator: 0.9.4
     optionalDependencies:
-      jiti: 2.6.1
+      jiti: 2.7.0
     transitivePeerDependencies:
       - supports-color
 
@@ -2869,7 +2872,7 @@ snapshots:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
 
-  jiti@2.6.1: {}
+  jiti@2.7.0: {}
 
   js-tokens@9.0.1: {}
 
@@ -3254,13 +3257,13 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  typescript-eslint@8.50.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
+  typescript-eslint@8.50.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.50.0(@typescript-eslint/parser@8.50.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.50.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.50.0(@typescript-eslint/parser@8.50.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.50.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
       '@typescript-eslint/typescript-estree': 8.50.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.50.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      eslint: 9.39.2(jiti@2.6.1)
+      '@typescript-eslint/utils': 8.50.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
+      eslint: 9.39.2(jiti@2.7.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -3292,7 +3295,7 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vite@7.3.0(@types/node@25.0.2)(jiti@2.6.1):
+  vite@7.3.0(@types/node@25.0.2)(jiti@2.7.0):
     dependencies:
       esbuild: 0.27.1
       fdir: 6.5.0(picomatch@4.0.3)
@@ -3303,12 +3306,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.0.2
       fsevents: 2.3.3
-      jiti: 2.6.1
+      jiti: 2.7.0
 
-  vitest@4.0.16(@types/node@25.0.2)(jiti@2.6.1):
+  vitest@4.0.16(@types/node@25.0.2)(jiti@2.7.0):
     dependencies:
       '@vitest/expect': 4.0.16
-      '@vitest/mocker': 4.0.16(vite@7.3.0(@types/node@25.0.2)(jiti@2.6.1))
+      '@vitest/mocker': 4.0.16(vite@7.3.0(@types/node@25.0.2)(jiti@2.7.0))
       '@vitest/pretty-format': 4.0.16
       '@vitest/runner': 4.0.16
       '@vitest/snapshot': 4.0.16
@@ -3325,7 +3328,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.0(@types/node@25.0.2)(jiti@2.6.1)
+      vite: 7.3.0(@types/node@25.0.2)(jiti@2.7.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.0.2

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,13 +60,26 @@ export function createContext<T = any>(
     }
   }
 
+  // Wrap object instances in a WeakRef before storing them in AsyncLocalStorage.
+  // A long-lived async resource (e.g. a timer) created inside `als.run()` pins the
+  // ALS store for its whole lifetime; storing the instance directly would keep the
+  // entire instance alive and leak memory. A WeakRef lets the instance be GC'd while
+  // the (tiny) wrapper is retained. Primitives can't be WeakRef targets, so they are
+  // stored as-is. https://github.com/unjs/unctx/issues/100
+  const _wrapInstance = (instance: T) =>
+    als && instance !== null && typeof instance === "object"
+      ? { __unctx_weak: new WeakRef(instance as object) }
+      : instance;
+  const _unwrapInstance = (store: any) =>
+    store && store.__unctx_weak ? store.__unctx_weak.deref() : store;
+
   const _getCurrentInstance = () => {
     // TODO: Investigate better solution to make sure currentInstance is in sync with AsyncLocalStorage
     // https://github.com/unjs/unctx/issues/100
     if (als /* && currentInstance === undefined */) {
-      const instance = als.getStore();
-      if (instance !== undefined) {
-        return instance;
+      const store = als.getStore();
+      if (store !== undefined) {
+        return _unwrapInstance(store);
       }
     }
     return currentInstance;
@@ -98,7 +111,7 @@ export function createContext<T = any>(
       checkConflict(instance);
       currentInstance = instance;
       try {
-        return als ? als.run(instance, callback) : callback();
+        return als ? als.run(_wrapInstance(instance), callback) : callback();
       } finally {
         if (!isSingleton) {
           currentInstance = undefined;
@@ -114,7 +127,7 @@ export function createContext<T = any>(
         currentInstance === instance ? onRestore : undefined;
       asyncHandlers.add(onLeave);
       try {
-        const r = als ? als.run(instance, callback) : callback();
+        const r = als ? als.run(_wrapInstance(instance), callback) : callback();
         if (!isSingleton) {
           currentInstance = undefined;
         }

--- a/test/async-context.test.ts
+++ b/test/async-context.test.ts
@@ -1,8 +1,22 @@
 import { AsyncLocalStorage } from "node:async_hooks";
+import v8 from "node:v8";
+import vm from "node:vm";
 import { describe, it, expect } from "vitest";
 import { createContext, executeAsync } from "../src/index.ts";
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Obtain a `gc()` function without requiring the `--expose-gc` node flag so the
+// memory-leak regression test runs in any environment (including CI).
+const gc: () => void = (() => {
+  if (typeof globalThis.gc === "function") return globalThis.gc;
+  try {
+    v8.setFlagsFromString("--expose-gc");
+    return vm.runInNewContext("gc");
+  } catch {
+    return undefined as unknown as () => void;
+  }
+})();
 
 describe("Async context", () => {
   it("AsyncLocalStorage works", async () => {
@@ -54,6 +68,53 @@ describe("Async context", () => {
 
     expect(result).toEqual(["A", "B", "C"]);
   });
+
+  it.runIf(typeof gc === "function")(
+    "does not leak instances pinned by long-lived async resources",
+    async () => {
+      const context = createContext<{ id: number; payload: Uint8Array }>({
+        asyncContext: true,
+        AsyncLocalStorage,
+      });
+
+      // A long-lived timer created *inside* the call pins the ALS store for its
+      // whole lifetime. Without a WeakRef wrapper this keeps the whole instance
+      // alive. The timer callback intentionally does not reference the instance.
+      const liveTimers: NodeJS.Timeout[] = [];
+
+      let collected = 0;
+      const total = 20;
+      const registry = new FinalizationRegistry(() => collected++);
+
+      for (let i = 0; i < total; i++) {
+        let instance: { id: number; payload: Uint8Array } | undefined = {
+          id: i,
+          payload: new Uint8Array(1024 * 1024),
+        };
+        registry.register(instance, i);
+
+        context.call(instance, () => {
+          // context is still readable inside the call
+          expect(context.use().id).toBe(i);
+          liveTimers.push(setInterval(() => {}, 1_000_000));
+        });
+
+        instance = undefined; // drop the only strong reference
+      }
+
+      for (let i = 0; i < 12; i++) {
+        gc();
+        await sleep(5);
+      }
+
+      for (const timer of liveTimers) {
+        clearInterval(timer);
+      }
+
+      // All instances must be collectable even though their timers are alive.
+      expect(collected).toBe(total);
+    },
+  );
 
   it("Context from use match correct context", async () => {
     const context = createContext({


### PR DESCRIPTION
resolves #125 

## Problem

When `call`/`callAsync` run a callback under `als.run(instance, cb)`, Node pins the `AsyncLocalStorage` **store** for as long as *any async resource created inside that run* stays alive. If a long-lived resource (a timer, a socket, a retained emitter) is created during the run, the whole `instance` stays reachable forever — a memory leak. In Nuxt this retains an entire per-request app/SSR context per request.

This is the same issue tracked in #100, and the fix mirrors the community patch from [`edison1105/nuxt4-asyncContext-memory-leak`](https://github.com/edison1105/nuxt4-asyncContext-memory-leak/blob/main/patches/unctx.patch).

## Fix

Store only a `WeakRef` to the instance in ALS, unwrapping on read. The tiny wrapper may be pinned by a leaked async resource, but the actual instance can now be garbage-collected.

- Object instances are wrapped as `{ __unctx_weak: new WeakRef(instance) }`.
- **Primitives are stored as-is** — `new WeakRef("A")` throws, and unctx's own tests use string contexts. (This guard is an addition over the raw dist patch, which would break those cases.)
- `use()`/`tryUse()` `deref()` the wrapper. Trade-off: if the instance is GC'd while a leaked resource later reads the context, `tryUse()` returns `undefined` where it previously returned the leaked-but-live instance. That is the intended behavior.

## Reproduction / test

Added a regression test in `test/async-context.test.ts`:

- Allocates 20 instances, each registered in a `FinalizationRegistry`.
- Runs each under `context.call(...)`, creating a `setInterval` inside the call (the leak trigger — a live timer pins the ALS store; the timer callback does **not** reference the instance).
- Drops all references, forces GC, and asserts all 20 are collected.

Verified it **fails without the fix** (`expected +0 to be 20` — every instance pinned) and **passes with it**. It obtains `gc()` via `v8.setFlagsFromString("--expose-gc")` + `vm.runInNewContext("gc")` so it runs in CI without the `--expose-gc` node flag.

I empirically checked which resources trigger the leak on Node 24 (`AsyncContextFrame`, the default): a **live timer** (`setInterval`/long `setTimeout`) pins the store; a pending `Promise` or `queueMicrotask` does not.

## Notes

- Also declares `jiti` as a dev dependency — `vitest.config.mjs` imports it directly but it was only present transitively, so `pnpm test` failed on a clean install here.
- `pnpm test:types` and `eslint`/`prettier` pass; full suite (32 tests) green.

---

🤖 This PR was written with [Claude Code](https://claude.com/claude-code) (Opus 4.8). The diff, the reproduction, and the empirical Node-version behavior were verified by running the tests locally; please review before merging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory management for instances used across asynchronous contexts, allowing unused instances to be garbage-collected even when long-lived asynchronous operations remain active.

* **Tests**
  * Added regression coverage to verify instance cleanup across supported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->