### PR TITLE
fix(transform): support async arrows with expression bodies

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -2,7 +2,6 @@ import type MagicString from "magic-string";
 import type {
   Node,
   CallExpression,
-  BlockStatement,
   AwaitExpression,
 } from "oxc-parser";
 
@@ -212,7 +211,8 @@ export async function createTransformer(
         return;
       }
 
-      const body = function_.body as BlockStatement;
+      const body = function_.body;
+      if (!body) return;
 
       let injectVariable = false;
       walk(body, function (node: MaybeHandledNode, parent) {
@@ -241,7 +241,13 @@ export async function createTransformer(
       });
 
       if (injectVariable) {
-        s.appendLeft(body.start + 1, "let __temp, __restore;");
+        if (body.type === "BlockStatement") {
+          s.appendLeft(body.start + 1, "let __temp, __restore;");
+        } else {
+          // Arrow function with an expression body: wrap it in a block statement
+          s.appendLeft(body.start, "{let __temp, __restore; return (");
+          s.appendRight(body.end, ");}");
+        }
       }
     }
 

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,9 +1,5 @@
 import type MagicString from "magic-string";
-import type {
-  Node,
-  CallExpression,
-  AwaitExpression,
-} from "oxc-parser";
+import type { Node, CallExpression, AwaitExpression } from "oxc-parser";
 
 export interface TransformerOptions {
   /**

--- a/test/async.test.ts
+++ b/test/async.test.ts
@@ -99,6 +99,27 @@ describe("callAsync", () => {
     console.warn = _warn;
   });
 
+  it("expression-bodied arrow restores context and returns value", async () => {
+    const context = createContext();
+    const result = await context.callAsync(
+      "A",
+      async () => (await sleep(1).then(() => "x")) + context.use(),
+    );
+    expect(result).toBe("xA");
+  });
+
+  it("withAsyncContext + expression-bodied arrow", async () => {
+    const context = createContext();
+    const _callAsync = context.callAsync; // Skip transform
+    const result = await _callAsync(
+      "A",
+      withAsyncContext(
+        async () => (await sleep(1).then(() => "x")) + context.use(),
+      ),
+    );
+    expect(result).toBe("xA");
+  });
+
   it("await but no async fn", async () => {
     const context = createContext();
     await context.callAsync("A", async () => {

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -352,7 +352,9 @@ describe("transforms", () => {
     const paramDefinition = transformer.transform(
       "withAsyncContext(async () => await something())",
     )?.code;
-    expect(paramDefinition).toMatchInlineSnapshot(`"import { executeAsync as __executeAsync } from "unctx";withAsyncContext(async () => {let __temp, __restore; return ((([__temp,__restore]=__executeAsync(()=>something())),__temp=await __temp,__restore(),__temp));},1)"`);
+    expect(paramDefinition).toMatchInlineSnapshot(
+      `"import { executeAsync as __executeAsync } from "unctx";withAsyncContext(async () => {let __temp, __restore; return ((([__temp,__restore]=__executeAsync(()=>something())),__temp=await __temp,__restore(),__temp));},1)"`,
+    );
   });
 
   describe("shouldTransform", () => {

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -335,6 +335,26 @@ describe("transforms", () => {
     `);
   });
 
+  it("transforms await in arrow function expression bodies", () => {
+    const objectDefinition = transform(`
+      export default defineSomething({
+        someKey: async route => (await something(route.path)).length > 0
+      })
+    `);
+    expect(objectDefinition).toMatchInlineSnapshot(`
+      "import { executeAsync as __executeAsync } from "unctx";
+      export default defineSomething({
+        someKey: async route => {let __temp, __restore; return (((([__temp,__restore]=__executeAsync(()=>something(route.path))),__temp=await __temp,__restore(),__temp)).length > 0);}
+      })
+      "
+    `);
+
+    const paramDefinition = transformer.transform(
+      "withAsyncContext(async () => await something())",
+    )?.code;
+    expect(paramDefinition).toMatchInlineSnapshot(`"import { executeAsync as __executeAsync } from "unctx";withAsyncContext(async () => {let __temp, __restore; return ((([__temp,__restore]=__executeAsync(()=>something())),__temp=await __temp,__restore(),__temp));},1)"`);
+  });
+
   describe("shouldTransform", () => {
     it("requires both a matched function and an await", () => {
       // matched function + await -> candidate for transform


### PR DESCRIPTION
resolves https://github.com/nuxt/nuxt/issues/20563

this fixes the transform of arrow functions with expression bodies, which wasn't handled until now

I removed the type cast of `function_.body`, because `oxc-parser` correctly types it as `FunctionBody | Expression`, though there is also `null` there, so I added a defensive early return just in case (even though I'm not actually 100% sure when a `null` value could get in there)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rewriting of `await` inside asynchronous arrow functions that use expression-style bodies (instead of block bodies).
  * Preserved original expression value semantics while injecting async-context handling safely, including correct behavior for returned expression results.
* **Tests**
  * Added Vitest cases covering `await` in arrow-function expression bodies and verifying async-context restoration for expression-bodied callbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->