### PR TITLE
fix: return null from tryUse when context is unavailable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -110,7 +110,7 @@ export function createContext<T = any>(
       return _instance;
     },
     tryUse: () => {
-      return _getCurrentInstance();
+      return _getCurrentInstance() ?? null;
     },
     set: (instance: T | undefined, replace?: boolean) => {
       if (!replace) {

--- a/test/async-context.test.ts
+++ b/test/async-context.test.ts
@@ -46,7 +46,7 @@ describe("Async context", () => {
       });
     });
 
-    expect(context.tryUse()).toBe(undefined);
+    expect(context.tryUse()).toBe(null);
   });
 
   it("call and use", async () => {
@@ -55,7 +55,7 @@ describe("Async context", () => {
       AsyncLocalStorage,
     });
 
-    expect(context.tryUse()).toBe(undefined);
+    expect(context.tryUse()).toBe(null);
 
     // Rename to avoid async transform
     const _callAsync = context.callAsync;

--- a/test/async.test.ts
+++ b/test/async.test.ts
@@ -7,7 +7,7 @@ const noop = () => {};
 describe("callAsync", () => {
   it("call and use", async () => {
     const context = createContext();
-    expect(context.tryUse()).toBe(undefined);
+    expect(context.tryUse()).toBe(null);
 
     const result = await Promise.all([
       context.callAsync("A", async () => {
@@ -38,7 +38,7 @@ describe("callAsync", () => {
     await _callAsync("A", async () => {
       expect(context.tryUse()).toBe("A");
       await sleep(1);
-      expect(context.tryUse()).toBe(undefined);
+      expect(context.tryUse()).toBe(null);
     });
   });
 
@@ -90,7 +90,7 @@ describe("callAsync", () => {
       _withAsyncContext(async () => {
         expect(context.use()).toBe("A");
         await sleep(1);
-        expect(context.tryUse()).toBe(undefined);
+        expect(context.tryUse()).toBe(null);
       }),
     );
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -5,7 +5,7 @@ describe("createContext", () => {
   it("call and use", () => {
     const context = createContext();
     expect(() => context.use()).toThrowError();
-    expect(context.tryUse()).toBe(undefined);
+    expect(context.tryUse()).toBe(null);
 
     const result = context.call("A", () => {
       expect(context.use()).toBe("A");
@@ -17,7 +17,7 @@ describe("createContext", () => {
 
   it("context conflict", () => {
     const context = createContext();
-    expect(context.tryUse()).toBe(undefined);
+    expect(context.tryUse()).toBe(null);
     context.call("A", () => {
       expect(() => context.call("B", vi.fn())).toThrow("Context conflict");
     });
@@ -35,11 +35,11 @@ describe("createContext", () => {
 
   it("use async", async () => {
     const context = createContext();
-    expect(context.tryUse()).toBe(undefined);
+    expect(context.tryUse()).toBe(null);
     const result = await context.call("A", async () => {
       expect(context.use()).toBe("A");
       await Promise.resolve();
-      expect(context.tryUse()).toBe(undefined);
+      expect(context.tryUse()).toBe(null);
       return "OK";
     });
     expect(result).toBe("OK");
@@ -56,13 +56,13 @@ describe("namespace", () => {
 describe("singleton", () => {
   it("set/unset", () => {
     const context = createContext();
-    expect(context.tryUse()).toBe(undefined);
+    expect(context.tryUse()).toBe(null);
     context.set("A");
     context.set("A");
     expect(context.use()).toBe("A");
     expect(context.use()).toBe("A");
     context.unset();
-    expect(context.tryUse()).toBe(undefined);
+    expect(context.tryUse()).toBe(null);
   });
 
   it("call compatibility", () => {


### PR DESCRIPTION
Resolves #146.

`tryUse()` is documented and typed to return `null` when no context is available, but the implementation currently returns `undefined`.

This change normalizes the missing value to `null` and updates the existing tests covering synchronous, asynchronous, singleton, and `AsyncLocalStorage` contexts.

Checks completed:

- `pnpm lint`
- `pnpm test:types`
- `pnpm build`
- Full Vitest coverage suite: 37 tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `tryUse()` now consistently returns `null` when no active context is available, matching its documented behavior.
* **Tests**
  * Updated coverage for synchronous, asynchronous, custom storage, and singleton scenarios to verify the corrected return value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->