### PR TITLE
fix: escape helper module paths in generated imports

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -191,7 +191,7 @@ export async function createTransformer(
 
     s.appendLeft(
       0,
-      `import { ${options.helperName} as __executeAsync } from "${options.helperModule}";`,
+      `import { ${options.helperName} as __executeAsync } from ${JSON.stringify(options.helperModule)};`,
     );
 
     return {

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -29,6 +29,18 @@ describe("transforms", () => {
     );
   });
 
+  it("escapes helper module paths", async () => {
+    const transformerWithWindowsPath = await createTransformer({
+      helperModule: String.raw`C:\project\src\index.ts`,
+    });
+
+    expect(
+      transformerWithWindowsPath.transform(
+        "withAsyncContext(async () => { await something() })",
+      )?.code,
+    ).toContain(String.raw`from "C:\\project\\src\\index.ts";`);
+  });
+
   it("throws on invalid syntax", () => {
     expect(() =>
       transformer.transform("withAsyncContext(async () => { await task()"),


### PR DESCRIPTION
Resolves #149.

The async context transform interpolated `helperModule` directly inside a quoted import. On Windows, absolute paths contain backslashes, which produced invalid escape sequences in the generated JavaScript and caused Rolldown to fail before tests could run.

This change serializes the module specifier with `JSON.stringify` before inserting it into the generated import. It also adds regression coverage using a Windows-style helper path.

Checks completed:

- `pnpm lint`
- `pnpm test:types`
- `pnpm build`
- `pnpm vitest run --coverage` - 38 tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of helper module paths containing special characters, including Windows-style paths.
  * Generated import statements now preserve valid escaping for module identifiers.

* **Tests**
  * Added regression coverage for correctly escaped helper module paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->